### PR TITLE
Fixing members pagination issue

### DIFF
--- a/buddypress/groups/single/members.php
+++ b/buddypress/groups/single/members.php
@@ -80,7 +80,7 @@
 
 	<?php do_action( 'bp_after_group_members_list' ); ?>
 
-	<div id="pag-bottom" class="pagination">
+	<div id="pag-bottom" class="pagination no-ajax">
 
 		<div class="pag-count" id="member-count-bottom">
 


### PR DESCRIPTION
page-top appears to have the no-ajax class that fixes this issue but page-bottom doesn't appear to have it. Adding the class fixes this issue. It appears to be related to this:

https://buddypress.trac.wordpress.org/ticket/3406