### PR TITLE
Update group email settings

### DIFF
--- a/buddypress/groups/single/admin.php
+++ b/buddypress/groups/single/admin.php
@@ -21,11 +21,6 @@
 
 	<?php do_action( 'groups_custom_group_fields_editable' ); ?>
 
-	<p>
-		<label for="group-notifiy-members">
-			<input type="checkbox" name="group-notify-members" value="1" /> <?php _e( 'Notify group members of these changes via email', 'boss' ); ?>
-		</label>
-	</p>
 
 	<?php do_action( 'bp_after_group_details_admin' ); ?>
 


### PR DESCRIPTION
Removing option to mass email users about group description changes.

https://trello.com/c/WS4uiekZ/351-update-group-email-settings