### PR TITLE
Add fix for groups with a homepage

### DIFF
--- a/js/boss-child.js
+++ b/js/boss-child.js
@@ -58,6 +58,8 @@
 
   $(document).ready(function(){
 
+    document.body.className = document.body.className.replace("activity","home");
+
     if ( $( ".cv p" ).length ) {
       $('.cv #bp-attachment-xprofile-file ').after("<span><button id='delete-upload'>Delete</button></span>");
 


### PR DESCRIPTION
When a group has a homepage, the activity page becomes seperate and the body class messes up the page.